### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://dev.azure.com/evotecpl/PSDiscord/_build/latest?definitionId=3"><img src="https://dev.azure.com/evotecpl/PSDiscord/_apis/build/status/EvotecIT.PSDiscord"></a>
   <a href="https://www.powershellgallery.com/packages/PSDiscord"><img src="https://img.shields.io/powershellgallery/v/PSDiscord.svg"></a>
-  <a href="https://www.powershellgallery.com/packages/PSDiscord"><img src="https://img.shields.io/powershellgallery/vpre/PSDiscord.svg?label=powershell%20gallery%20preview&colorB=yellow"></a>
+  <a href="https://www.powershellgallery.com/packages/PSDiscord"><img src="https://img.shields.io/powershellgallery/v/PSDiscord.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases"></a>
   <a href="https://github.com/EvotecIT/PSDiscord"><img src="https://img.shields.io/github/license/EvotecIT/PSDiscord.svg"></a>
 </p>
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583